### PR TITLE
Fixing date in comments

### DIFF
--- a/inc/Partials/Comment_Single.php
+++ b/inc/Partials/Comment_Single.php
@@ -22,7 +22,7 @@
                     endif;
                     ?>
                     
-                    <span class="text-muted"><small><?php echo human_time_diff( get_the_time('U'), current_time('timestamp') ) . ' ' .  __('ago', 'gitsta') ?></small></span>
+                    <span class="text-muted"><small><?php echo human_time_diff( get_comment_time('U'), current_time('timestamp') ) . ' ' .  __('ago', 'gitsta') ?></small></span>
 
                     <span class="pull-right">
                         <?php echo edit_comment_link('<i class="fa fa-edit"></i> Edit'); ?>


### PR DESCRIPTION
Fixing date in comments. Previously, in human_time_diff(...) function, **date of the post** was compared with the current date in every comment. Now, in human_time_diff(...) function, **date of the comment** is compared with the current date, so comment time is displayed correctly.
