### PR TITLE
updating date format to 'Y-m-d' in theme

### DIFF
--- a/content-page.php
+++ b/content-page.php
@@ -1,7 +1,7 @@
 <div id="post-<?php the_ID(); ?>" class="item">
     <div name="meta">
         <p class="text-muted">
-            <i class="fa fa-calendar"></i> <?php echo the_date(); ?>
+            <i class="fa fa-calendar"></i> <?php echo the_date("Y-m-d"); ?>
 
             <span class="pull-right">
                  <?php edit_post_link('<i class="fa fa-edit"></i> ' . __('Edit', 'gitsta')); ?> 

--- a/content-single.php
+++ b/content-single.php
@@ -1,7 +1,7 @@
 <div id="post-<?php the_ID(); ?>" <?php post_class('item'); ?>>
     <div name="meta">
         <p class="text-muted">
-            <i class="fa fa-calendar"></i> <?php echo the_date(); ?>
+            <i class="fa fa-calendar"></i> <?php echo the_date("Y-m-d"); ?>
 
             <i class="fa fa-folder-open" style="margin-left: 20px;"></i> 
             <?php

--- a/content.php
+++ b/content.php
@@ -7,9 +7,9 @@
             <i class="fa fa-calendar"></i>
             <?php
             if(trim(get_the_title()) != "") {
-                echo get_the_date();
+                echo get_the_date("Y-m-d");
             } else {
-                echo '<a href="'. get_the_permalink() .'" name="'. get_the_ID() .'" rel="bookmark">'. get_the_date() .'</a>';
+                echo '<a href="'. get_the_permalink() .'" name="'. get_the_ID() .'" rel="bookmark">'. get_the_date("Y-m-d") .'</a>';
             }
             ?>
 


### PR DESCRIPTION
In this PR, I'm updating date format to 'Y-m-d' (year-month-day) on a page with a list of posts, single post, and single page.

I find it useful because readers of the blog may find an old article (e.g. via search) and by default they see just month name and number of the day of the month, but they don't see year, so they may not have any clue if information included in the article is "fresh" or old and outdated. In particular cases it may be important.

I used this reference for date formatting:
- https://developer.wordpress.org/reference/functions/the_date/
- https://developer.wordpress.org/reference/functions/get_the_date/
- http://php.net/manual/en/function.date.php